### PR TITLE
Only request data within the published bounds and increase tile size

### DIFF
--- a/js/on_load.js
+++ b/js/on_load.js
@@ -4,8 +4,8 @@ window.onload = function() {
     // set this flag to false for better performance
     window.TILED_WMS = true;
     // initialize the app and specify the CRS
-    initialize('EPSG:4326');
-    // initialize('EPSG:3857');
+    // initialize('EPSG:4326');
+    initialize('EPSG:3857');
 };
 
 function initialize(crs) {


### PR DESCRIPTION
Some data does not align perfectly to the projection max bounds.  We need to take the reported bounding box from the Capabilities and use it in our requests, otherwise we will request out of bounds data that will come back transparent.

I also added a change to the tile size.  The default of 256x256 is fairly small and results in the browser queuing up requests and it feels slow.  It It should be dynamic, but for now the hardcoded values have a much faster feel to me.

